### PR TITLE
Pseudo ternary operator to get throttle value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on and uses the types of changes according to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.1] - 2023-01-18
+
+### Changed
+
+- SPSWakeUp.ps1
+  - Replaced if-elseif-else logic with pseudo ternary operator to get throttle value.
+
 ## [2.6.0] - 2022-10-27
 
 ### Added

--- a/Scripts/SPSWakeUP.ps1
+++ b/Scripts/SPSWakeUP.ps1
@@ -42,7 +42,7 @@
     FileName:	SPSWakeUP.ps1
     Author:		luigilink (Jean-Cyril DROUHIN)
     Date:		July 16, 2021
-    Version:	2.6.0
+    Version:	2.6.1
     Licence:	MIT License
 
     .LINK
@@ -76,7 +76,7 @@ Clear-Host
 $Host.UI.RawUI.WindowTitle = "WarmUP script running on $env:COMPUTERNAME"
 
 # Define variable
-$spsWakeupVersion = '2.6.0'
+$spsWakeupVersion = '2.6.1'
 $currentUser = ([Security.Principal.WindowsIdentity]::GetCurrent()).Name
 $scriptRootPath = Split-Path -parent $MyInvocation.MyCommand.Definition
 
@@ -497,18 +497,7 @@ function Get-SPSThrottleLimit
         $cimInstanceSocket = $cimInstanceProc.count
         $numLogicalCpu = $cimInstanceProc[0].NumberOfLogicalProcessors * $cimInstanceSocket
 
-        if ($numLogicalCpu -le 2)
-        {
-            $NumThrottle = 2 * $numLogicalCpu
-        }
-        elseif ($numLogicalCpu -ge 8)
-        {
-            $NumThrottle = 10
-        }
-        else
-        {
-            $NumThrottle = 2 * $numLogicalCpu
-        }
+        $NumThrottle = @{ $true = 10; $false = 2 * $numLogicalCpu }[$numLogicalCpu -ge 8]
     }
     catch
     {


### PR DESCRIPTION
Replaced multiple if-elseif-else logic with pseudo ternary operator.

The structure of the if-elseif-else statement to determine the throttle value contained superfluous logic and it seemed more succinct to replace it with a pseudo ternary operator. Essentially, the throttle value is always twice the number of logical CPUs unless the number of logical CPUs is greater than or equal to 8.

- [x] Change details added to Unreleased section of changelog.md?
- [ ] Added/updated documentation and descriptions where appropriate?
- [ ] Examples updated in the examples folder?
- [ ] New/changed code adheres to [Style Guidelines]?
- [ ] [Unit tests] created/updated where possible?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luigilink/spswakeup/15)
<!-- Reviewable:end -->
